### PR TITLE
Change initial bgcolor to None

### DIFF
--- a/gui/widgets/label.py
+++ b/gui/widgets/label.py
@@ -20,7 +20,7 @@ class Label(Widget):
         text,
         invert=False,
         fgcolor=None,
-        bgcolor=BLACK,
+        bgcolor=None,
         bdcolor=False,
         justify=0,
     ):


### PR DESCRIPTION
In label widget, for background color other than black, bgcolor should be initially None (otherwise it is always black).